### PR TITLE
Fix crash when long pressing a deck in the decks list.

### DIFF
--- a/vampiDroid/src/main/java/name/vampidroid/fragments/DecksListFragment.java
+++ b/vampiDroid/src/main/java/name/vampidroid/fragments/DecksListFragment.java
@@ -37,7 +37,7 @@ public class DecksListFragment extends SherlockListFragment {
 
 		Cursor c = DatabaseHelper.getDecksWithCardsCount();
 
-		mAdapter = new SimpleCursorAdapter(getActivity().getApplicationContext(), R.layout.deckslistitem, c,
+		mAdapter = new SimpleCursorAdapter(getActivity(), R.layout.deckslistitem, c,
 				new String[] { "Name", "CryptCardsCount", "LibraryCardsCount", "CryptCapacityAvg", "CryptCapacityMin", "CryptCapacityMax"  }, new int[] { R.id.txtCardName,
 						R.id.txtCryptCardsCount, R.id.txtLibraryCardsCount, R.id.txtCryptCapacityAvg, R.id.txtCryptCapacityMin, R.id.txtCryptCapacityMax  });
 
@@ -130,13 +130,13 @@ public class DecksListFragment extends SherlockListFragment {
 		startActivity(i);
 
 	}
-	
+
 	
 	@Override
 	public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
 
-		MenuInflater inflater = getSherlockActivity().getSupportMenuInflater();
-		inflater.inflate(R.menu.decks_list_context_menu, (Menu) menu);
+		android.view.MenuInflater inflater = getSherlockActivity().getMenuInflater();
+		inflater.inflate(R.menu.decks_list_context_menu, menu);
 
 		AdapterView.AdapterContextMenuInfo info = (AdapterView.AdapterContextMenuInfo) menuInfo;
 


### PR DESCRIPTION
Fix #13
Thanks user who reported it through Google Play crash reporter.

More info here: http://stackoverflow.com/questions/14468209/how-can-i-provide-a-contextmenu-in-a-listview-when-using-the-support-library