### PR TITLE
Add more optimizations to images loading.

### DIFF
--- a/vampiDroid/src/main/java/name/vampidroid/CardListCursorAdapter.java
+++ b/vampiDroid/src/main/java/name/vampidroid/CardListCursorAdapter.java
@@ -2,9 +2,12 @@ package name.vampidroid;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
 import android.support.v4.widget.SimpleCursorAdapter;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -155,8 +158,8 @@ public class CardListCursorAdapter extends SimpleCursorAdapter {
 
             int disIndex = 0;
             for (String discipline : disciplines) {
-                //viewHolder.disciplineImageViews[disIndex].setImageDrawable(imageViewsDrawablesMap.get(discipline));
-                viewHolder.disciplineImageViews[disIndex].setImageBitmap(imageViewsDrawablesMap.get(discipline));
+                viewHolder.disciplineImageViews[disIndex].setImageDrawable(imageViewsDrawablesMap.get(discipline));
+                //viewHolder.disciplineImageViews[disIndex].setImageBitmap(imageViewsDrawablesMap.get(discipline));
                 viewHolder.disciplineImageViews[disIndex].setVisibility(View.VISIBLE);
                 disIndex++;
             }
@@ -194,7 +197,7 @@ public class CardListCursorAdapter extends SimpleCursorAdapter {
 	}
 
 
-    public static final HashMap<String, Bitmap> imageViewsDrawablesMap = new HashMap<>();
+    public static final HashMap<String, Drawable> imageViewsDrawablesMap = new HashMap<>();
 
 
     public static void fillImageViewsDrawablesMap(Context context) {
@@ -203,63 +206,64 @@ public class CardListCursorAdapter extends SimpleCursorAdapter {
 
             BitmapFactory.Options options = new BitmapFactory.Options();
             options.inSampleSize = 4;
+            Resources res = context.getResources();
 
-            imageViewsDrawablesMap.put("abo", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_abombwe, options));
-            imageViewsDrawablesMap.put("ABO", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_abombwe_sup, options));
-            imageViewsDrawablesMap.put("ani", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_animalism, options));
-            imageViewsDrawablesMap.put("ANI", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_animalism_sup, options));
-            imageViewsDrawablesMap.put("aus", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_auspex, options));
-            imageViewsDrawablesMap.put("AUS", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_auspex_sup, options));
-            imageViewsDrawablesMap.put("cel", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_celerity, options));
-            imageViewsDrawablesMap.put("CEL", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_celerity_sup, options));
-            imageViewsDrawablesMap.put("chi", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_chimerstry, options));
-            imageViewsDrawablesMap.put("CHI", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_chimerstry_sup, options));
-            imageViewsDrawablesMap.put("dai", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_daimoinon, options));
-            imageViewsDrawablesMap.put("DAI", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_daimoinon_sup, options));
-            imageViewsDrawablesMap.put("dem", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_dementation, options));
-            imageViewsDrawablesMap.put("DEM", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_dementation_sup, options));
-            imageViewsDrawablesMap.put("dom", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_dominate, options));
-            imageViewsDrawablesMap.put("DOM", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_dominate_sup, options));
-            imageViewsDrawablesMap.put("for", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_fortitude, options));
-            imageViewsDrawablesMap.put("FOR", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_fortitude_sup, options));
-            imageViewsDrawablesMap.put("mel", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_melpominee, options));
-            imageViewsDrawablesMap.put("MEL", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_melpominee_sup, options));
-            imageViewsDrawablesMap.put("myt", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_mytherceria, options));
-            imageViewsDrawablesMap.put("MYT", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_mytherceria_sup, options));
-            imageViewsDrawablesMap.put("nec", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_necromancy, options));
-            imageViewsDrawablesMap.put("NEC", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_necromancy_sup, options));
-            imageViewsDrawablesMap.put("obe", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_obeah, options));
-            imageViewsDrawablesMap.put("OBE", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_obeah_sup, options));
-            imageViewsDrawablesMap.put("obf", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_obfuscate, options));
-            imageViewsDrawablesMap.put("OBF", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_obfuscate_sup, options));
-            imageViewsDrawablesMap.put("obt", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_obtenebration, options));
-            imageViewsDrawablesMap.put("OBT", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_obtenebration_sup, options));
-            imageViewsDrawablesMap.put("pot", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_potence, options));
-            imageViewsDrawablesMap.put("POT", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_potence_sup, options));
-            imageViewsDrawablesMap.put("pre", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_presence, options));
-            imageViewsDrawablesMap.put("PRE", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_presence_sup, options));
-            imageViewsDrawablesMap.put("pro", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_protean, options));
-            imageViewsDrawablesMap.put("PRO", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_protean_sup, options));
-            imageViewsDrawablesMap.put("qui", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_quietus, options));
-            imageViewsDrawablesMap.put("QUI", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_quietus_sup, options));
-            imageViewsDrawablesMap.put("san", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_sanguinus, options));
-            imageViewsDrawablesMap.put("SAN", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_sanguinus_sup, options));
-            imageViewsDrawablesMap.put("ser", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_serpentis, options));
-            imageViewsDrawablesMap.put("SER", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_serpentis_sup, options));
-            imageViewsDrawablesMap.put("spi", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_spiritus, options));
-            imageViewsDrawablesMap.put("SPI", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_spiritus_sup, options));
-            imageViewsDrawablesMap.put("tem", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_temporis, options));
-            imageViewsDrawablesMap.put("TEM", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_temporis_sup, options));
-            imageViewsDrawablesMap.put("thn", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_thanatosis, options));
-            imageViewsDrawablesMap.put("THN", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_thanatosis_sup, options));
-            imageViewsDrawablesMap.put("tha", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_thaumaturgy, options));
-            imageViewsDrawablesMap.put("THA", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_thaumaturgy_sup, options));
-            imageViewsDrawablesMap.put("val", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_valeren, options));
-            imageViewsDrawablesMap.put("VAL", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_valeren_sup, options));
-            imageViewsDrawablesMap.put("vic", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_vicissitude, options));
-            imageViewsDrawablesMap.put("VIC", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_vicissitude_sup, options));
-            imageViewsDrawablesMap.put("vis", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_visceratika, options));
-            imageViewsDrawablesMap.put("VIS", BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_dis_visceratika_sup, options));
+            imageViewsDrawablesMap.put("abo", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_abombwe, options)));
+            imageViewsDrawablesMap.put("ABO", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_abombwe_sup, options)));
+            imageViewsDrawablesMap.put("ani", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_animalism, options)));
+            imageViewsDrawablesMap.put("ANI", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_animalism_sup, options)));
+            imageViewsDrawablesMap.put("aus", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_auspex, options)));
+            imageViewsDrawablesMap.put("AUS", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_auspex_sup, options)));
+            imageViewsDrawablesMap.put("cel", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_celerity, options)));
+            imageViewsDrawablesMap.put("CEL", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_celerity_sup, options)));
+            imageViewsDrawablesMap.put("chi", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_chimerstry, options)));
+            imageViewsDrawablesMap.put("CHI", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_chimerstry_sup, options)));
+            imageViewsDrawablesMap.put("dai", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_daimoinon, options)));
+            imageViewsDrawablesMap.put("DAI", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_daimoinon_sup, options)));
+            imageViewsDrawablesMap.put("dem", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_dementation, options)));
+            imageViewsDrawablesMap.put("DEM", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_dementation_sup, options)));
+            imageViewsDrawablesMap.put("dom", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_dominate, options)));
+            imageViewsDrawablesMap.put("DOM", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_dominate_sup, options)));
+            imageViewsDrawablesMap.put("for", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_fortitude, options)));
+            imageViewsDrawablesMap.put("FOR", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_fortitude_sup, options)));
+            imageViewsDrawablesMap.put("mel", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_melpominee, options)));
+            imageViewsDrawablesMap.put("MEL", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_melpominee_sup, options)));
+            imageViewsDrawablesMap.put("myt", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_mytherceria, options)));
+            imageViewsDrawablesMap.put("MYT", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_mytherceria_sup, options)));
+            imageViewsDrawablesMap.put("nec", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_necromancy, options)));
+            imageViewsDrawablesMap.put("NEC", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_necromancy_sup, options)));
+            imageViewsDrawablesMap.put("obe", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_obeah, options)));
+            imageViewsDrawablesMap.put("OBE", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_obeah_sup, options)));
+            imageViewsDrawablesMap.put("obf", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_obfuscate, options)));
+            imageViewsDrawablesMap.put("OBF", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_obfuscate_sup, options)));
+            imageViewsDrawablesMap.put("obt", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_obtenebration, options)));
+            imageViewsDrawablesMap.put("OBT", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_obtenebration_sup, options)));
+            imageViewsDrawablesMap.put("pot", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_potence, options)));
+            imageViewsDrawablesMap.put("POT", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_potence_sup, options)));
+            imageViewsDrawablesMap.put("pre", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_presence, options)));
+            imageViewsDrawablesMap.put("PRE", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_presence_sup, options)));
+            imageViewsDrawablesMap.put("pro", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_protean, options)));
+            imageViewsDrawablesMap.put("PRO", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_protean_sup, options)));
+            imageViewsDrawablesMap.put("qui", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_quietus, options)));
+            imageViewsDrawablesMap.put("QUI", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_quietus_sup, options)));
+            imageViewsDrawablesMap.put("san", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_sanguinus, options)));
+            imageViewsDrawablesMap.put("SAN", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_sanguinus_sup, options)));
+            imageViewsDrawablesMap.put("ser", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_serpentis, options)));
+            imageViewsDrawablesMap.put("SER", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_serpentis_sup, options)));
+            imageViewsDrawablesMap.put("spi", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_spiritus, options)));
+            imageViewsDrawablesMap.put("SPI", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_spiritus_sup, options)));
+            imageViewsDrawablesMap.put("tem", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_temporis, options)));
+            imageViewsDrawablesMap.put("TEM", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_temporis_sup, options)));
+            imageViewsDrawablesMap.put("thn", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_thanatosis, options)));
+            imageViewsDrawablesMap.put("THN", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_thanatosis_sup, options)));
+            imageViewsDrawablesMap.put("tha", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_thaumaturgy, options)));
+            imageViewsDrawablesMap.put("THA", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_thaumaturgy_sup, options)));
+            imageViewsDrawablesMap.put("val", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_valeren, options)));
+            imageViewsDrawablesMap.put("VAL", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_valeren_sup, options)));
+            imageViewsDrawablesMap.put("vic", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_vicissitude, options)));
+            imageViewsDrawablesMap.put("VIC", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_vicissitude_sup, options)));
+            imageViewsDrawablesMap.put("vis", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_visceratika, options)));
+            imageViewsDrawablesMap.put("VIS", new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_dis_visceratika_sup, options)));
         }
     }
 


### PR DESCRIPTION
setImageBitmap creates a new BitmapDrawable and calls setImageDrawable.
So, instead of using setImageBitmap, create the BitmapDrawable which
will be cached and call setImageDrawable directly.

This will reduce pressure in the GC by avoiding the creation of a lot
of BitmapDrawable objects when calling setImageBitmap a lot of times.